### PR TITLE
fix: update building steps

### DIFF
--- a/network-documentation/near/tutorials/5.-writing-and-deploying-your-first-near-smart-contract.md
+++ b/network-documentation/near/tutorials/5.-writing-and-deploying-your-first-near-smart-contract.md
@@ -62,35 +62,24 @@ First, create a new file in the current project directory, named `asconfig.json`
 
 ```javascript
 {
-  "extends": "near-sdk-as/asconfig.json"
+  "extends": "near-sdk-as/asconfig.json",
+  "options": {
+     "binaryFile": "./contract.wasm",
+     "measure": true
+  },
+  "entry": "./contract.ts"
 }
 ```
 
-Next, create a new file `asconfig.js` with the compilation steps from the following code:
-
-```javascript
-const { compile } = require("near-sdk-as/compiler");
-
-compile(
-  "./contract.ts", "",
-  [
-    "--runPasses", "inlining-optimizing,dce",
-    "--binaryFile", "./contract.wasm",
-    "--measure",
-  ],
-  { verbose: false }
-);
-```
-
-Package `near-sdk-as/compiler` essentially provides a wrapper for the `asb`, a tool to compile .ts scripts -&gt; .wasm binary blobs. You can run `./node_modules/.bin/asb --help` to see the list of all available options if you're interested.
+Next you use`asb`, a tool to compile AssemblyScript files -&gt; .wasm binary blobs. You can run `npx asb --help` or `./node_modules/.bin/asb --help` to see the list of all available options if you're interested.
 
 With all the bits in place, we are ready to compile our contract. Run the following command:
 
 ```javascript
-node asconfig.js
+npx asb
 ```
 
-The command output might look something like:
+This builds the relase target and the output might look something like:
 
 ```javascript
 I/O Read   :     5.802 ms  n=350
@@ -107,6 +96,8 @@ Transform  :          n/a  n=4
 You should be able to find a newly created file `contract.wasm` in the current directory.
 
 Great job! We have successfully compiled our first smart contract into a WebAssembly binary and ready to deploy it to the NEAR network using DataHub.
+
+Note: If you want to compile a non-optimized binary with debug info run `npx asb --target debug`.
 
 ## Deploying the Contract
 


### PR DESCRIPTION
The use of the compile scripts was the old way and the compiler file provided was only to assist in backwards compatibility.

I updated the example to still compile to the name you wanted.  However, the preferred way is to use an `assembly` folder with `index.ts` and then the name of the contract comes from a package.json.