### PR TITLE
Polkadot Pathway: Next steps tutorial link broken

### DIFF
--- a/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/1.-connecting-to-a-polkadot-node-with-datahub.md
+++ b/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/1.-connecting-to-a-polkadot-node-with-datahub.md
@@ -214,10 +214,6 @@ The following line is the timestamp which we requested via the API query method 
 
 ## Next Steps
 
-{% hint style="danger" %}
-The complete code for this tutorial can be found on [GitHub](https://github.com/figment-networks/tutorials/tree/polkadot/polkadot/1_connecting_to_node).
-{% endhint %}
-
 Congratulations!  In this tutorial, we learned how to use environment variables to keep sensitive information out of our code, and also how to connect to the Polkadot API using an RPC Provider. We  successfully connected to a DataHub hosted Polkadot node and performed an API query to the node using a simple method chain. 
 
 Stand up and stretch, get a drink of water, take a few deep breaths. Give yourself a pat on the back for learning something new, then get ready for the next step.


### PR DESCRIPTION
Removed link to Polkadot tutorial that leads to a 404... I could not find a valid link in the tutorials directory.