### PR TITLE
Fix text in 4.-submit-a-transaction.md

### DIFF
--- a/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/4.-submit-a-transaction.md
+++ b/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/4.-submit-a-transaction.md
@@ -63,7 +63,7 @@ main().catch((err) => {
 }).finally(() => process.exit());
 ```
 
-Beyond the `wsProvider`, `api` and `keyring` constants which we are using to initialize our connection to DataHub and manage our keyring, we will also define `AMOUNT` and `RECIPIENT_ADDRESS`. 
+Beyond the `httpProvider`, `api` and `keyring` constants which we are using to initialize our connection to DataHub and manage our keyring, we will also define `AMOUNT` and `RECIPIENT_ADDRESS`. 
 
 Initializing access to our account via the mnemonic seed phrase we have stored in `.env` using `keyring.addFromUri()` and then using `api.query.system.account()` to look at the balance of an account. Once again, we use environment variables to keep important information safe and out of our code.
 


### PR DESCRIPTION
There is no `wsProvider`, the example used `httpProvider` as it's a Http RPC call, not a WebSocket example.