### PR TITLE
Add derivation key to metadata before it is referenced

### DIFF
--- a/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/2.-create-a-polkadot-account.md
+++ b/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/2.-create-a-polkadot-account.md
@@ -87,7 +87,7 @@ Paste this snippet beneath the comment `// 2. Create an account` :
 
 ```javascript
 // Add account with keypair from the generated mnemonic
-const newAccount = await keyring.addFromUri(`${MNEMONIC}`, { name: 'new keypair'})
+const newAccount = await keyring.addFromUri(`${MNEMONIC}`, { name: 'new keypair', derivation: 'root'})
 
 // Show the pair has been added to our keyring
 console.log(keyring.pairs.length, ' available keypair(s)')


### PR DESCRIPTION
On line 96, we log `newAccount.meta.derivation` but it is not set on line 90. On line 106 this `.addFromUri` call, with no derivation, is performed as proposed in this change.