### PR TITLE
Update referenced constant name

### DIFF
--- a/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/4.-submit-a-transaction.md
+++ b/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/4.-submit-a-transaction.md
@@ -65,7 +65,7 @@ main().catch((err) => {
 }).finally(() => process.exit());
 ```
 
-Beyond the `wsProvider`, `api` and `keyring` constants which we are using to initialize our connection to DataHub and manage our keyring, we will also define `AMOUNT` and `RECIPIENT_ADDRESS`. 
+Beyond the `httpProvider`, `api` and `keyring` constants which we are using to initialize our connection to DataHub and manage our keyring, we will also define `AMOUNT` and `RECIPIENT_ADDRESS`. 
 
 Initializing access to our account via the mnemonic seed phrase we have stored in `.env` using `keyring.addFromUri()` and then using `api.query.system.account()` to look at the balance of an account. Once again, we use environment variables to keep important information safe and out of our code.
 


### PR DESCRIPTION
On line 68 we reference three constants, `wsProvider`, `api` and `keyring`. In the code sample being referenced, `wsProvider` does not exist and is instead named `httpProvider`, this updates the reference on line 68 to match the code sample. (The name in the code sample also matches preceding code samples in previous steps.)