### PR TITLE
Update referenced endpoint to match code

### DIFF
--- a/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/6.-search-for-transactions.md
+++ b/network-documentation/polkadot/tutorials/intro-pathway-polkadot-basics/6.-search-for-transactions.md
@@ -70,7 +70,7 @@ try {
 }
 ```
 
-Here, we are using `POST` to request 5 recent transactions from the `/transaction_search` endpoint. The  specified `network` is Polkadot and the `chain_id` is Mainnet. Uppercase strings are not necessary for the request. Notice how we set the `limit` to 5. Altering this number would return a different number of results. Be careful not to set this too high or you will flood your terminal with too much output. Consider logging to a file if more output is required. 
+Here, we are using `POST` to request 5 recent transactions from the `/transactions_search` endpoint. The  specified `network` is Polkadot and the `chain_id` is Mainnet. Uppercase strings are not necessary for the request. Notice how we set the `limit` to 5. Altering this number would return a different number of results. Be careful not to set this too high or you will flood your terminal with too much output. Consider logging to a file if more output is required. 
 
 ## Get the 5 last transactions for my address
 


### PR DESCRIPTION
On line 73 we reference the `/transaction_search` endpoint, which is `/transactions_search` in the code.