### PR TITLE
id field missing on response specification on transaction-search.md

### DIFF
--- a/network-documentation/polkadot/enriched-apis/transaction-search.md
+++ b/network-documentation/polkadot/enriched-apis/transaction-search.md
@@ -104,6 +104,7 @@ Success response
 
 ```javascript
 {
+    "id": "string",
     "hash": "string",
     "block_hash": "string",
     "chain_id": "string",


### PR DESCRIPTION
id field missing on response specification.