### PR TITLE
celo broken tutorial fixed

### DIFF
--- a/network-documentation/celo/tutorial/celo-contract-from-ethereum.md
+++ b/network-documentation/celo/tutorial/celo-contract-from-ethereum.md
@@ -1,0 +1,282 @@
+# How to customize an Ethereum smart contract for the Celo network
+
+The Celo blockchain is completely independent from the Ethereum blockchain, but both compile their smart contracts to [EVM](https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc) bytecode.  This means that any smart contract written for the Ethereum blockchain is already compatible with the Celo network.  
+
+To better understand this relationship, we’re going to take the faucet code from [Chapter 7](https://github.com/ethereumbook/ethereumbook/blob/develop/07smart-contracts-solidity.asciidoc) of the [Ethereum book](https://github.com/ethereumbook/ethereumbook), and customize it for the Celo network. 
+
+Please note that while this contract is written in Solidity, contracts written in any EVM compatible high level programming language (LLL, Serpent, Mutan) can be used for Celo.  As long as the code is compiled to run on an [Ethereum Virtual Machine](-  [The Ethereum Virtual Machine](https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc)) it is compatible with both chains.  
+
+### If the contract already works, then why would we want to alter it?  
+Celo's native currency, CELO, is also an ERC-20 compliant token.  The same is true for Celo's stablecoin, cUSD.  We'll see in the next section that our basic Ethereum faucet does not account for ERC-20 tokens.  When it is run on the Celo blockchain, it will assume we want to withdraw the native currency, CELO, as default.  
+
+This tutorial aims to show how we can rewrite the faucet and capitalize on the fact that CELO is an ERC-20 compliant token just like its stablecoin, cUSD. 
+
+## Original Faucet code
+Below is the [code](https://raw.githubusercontent.com/ethereumbook/ethereumbook/develop/code/Solidity/Faucet8.sol) from the Ethereum book.  
+
+````
+// SPDX-License-Identifier: CC-BY-SA-4.0
+
+// Version of Solidity compiler this program was written for
+pragma solidity ^0.6.4;
+
+contract Owned {
+    address payable owner;
+
+    // Contract constructor: set owner
+    constructor() public {
+        owner = msg.sender;
+    }
+
+    // Access control modifier
+    modifier onlyOwner {
+        require(msg.sender == owner, "Only the contract owner can call this function");
+        _;
+    }
+}
+
+contract Mortal is Owned {
+    // Contract destructor
+    function destroy() public onlyOwner {
+        selfdestruct(owner);
+    }
+}
+
+contract Faucet is Mortal {
+    event Withdrawal(address indexed to, uint amount);
+    event Deposit(address indexed from, uint amount);
+
+    // Accept any incoming amount
+    receive() external payable {
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    // Give out ether to anyone who asks
+    function withdraw(uint withdraw_amount) public {
+        // Limit withdrawal amount
+        require(withdraw_amount <= 0.1 ether);
+
+        require(
+            address(this).balance >= withdraw_amount,
+            "Insufficient balance in faucet for withdrawal request"
+        );
+
+        // Send the amount to the address that requested it
+        msg.sender.transfer(withdraw_amount);
+
+        emit Withdrawal(msg.sender, withdraw_amount);
+    }
+}
+````
+
+
+If we were to deploy this contract on the Celo network as is, it would work for withdrawing the native currency, Celo.  This is because Celo is equivalent to Ether in Solidity contracts like this.  
+
+But what about Celo's stable currency, cUSD?  How would we withdraw that token from this faucet?
+
+To withdraw a specific token, we will have to rewrite our faucet to consider ERC-20 tokens.  
+
+## Rewriting the Faucet
+
+While we're at it, we should utilize the [Open Zeppelin](https://github.com/pkdcryptos/OpenZeppelin-openzeppelin-solidity) library to avoid rewriting code that has already have been security audited and used in many Ethereum contracts without issue.  There is no guaruntee these contracts will provide absolute safety, but they've been tested and can be trusted more than any custom ones we whip up.  
+
+First, we'll remove our Owned and Mortal contracts and import Open Zeppelin contracts instead.
+
+Add the Open Zeppelin library to your project.
+````
+npm install openzeppelin-solidity
+````
+
+Now we can import the relevant contracts in our Faucet.sol file. 
+
+The Owned and Mortal contracts from the code above are replaced below with the Open Zeppelin access contract called Ownable.  Instead of us having to write basic behavior like this for every Solidity project, we can just utilize this library instead.  
+
+The [Ownable](https://github.com/pkdcryptos/OpenZeppelin-openzeppelin-solidity/blob/master/contracts/ownership/Ownable.sol) contract provides administrative access control over the faucet.  Only the creator of the contract can destroy the contract.  What's nice about the Open Zeppelin contract is it adds a bit more functionality than ours.  Specifically the ability to transfer or renounce ownership over a contract.  
+
+
+Our updated Faucet.sol file now has these imports at the top:
+
+````
+pragma solidity >=0.8.0;
+
+import "../node_modules/openzeppelin-solidity/contracts/security/ReentrancyGuard.sol";
+import "../node_modules/openzeppelin-solidity/contracts/access/Ownable.sol";
+
+import "../node_modules/openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+contract Faucet is ReentrancyGuard, Ownable {
+  // ...
+}  
+
+````
+
+We also added the [Reentrancy Guard](https://github.com/pkdcryptos/OpenZeppelin-openzeppelin-solidity/blob/master/contracts/utils/ReentrancyGuard.sol) contract to protect against nested calls to our faucet.  We didn't need to add this for our faucet to be functional, but we should follow best practices to secure our code and protect our users and ourselves.  
+
+To complete our contract and have it work for both Celo and cUSD, we have to update our withdraw function.  
+
+Everything else stays the same.  Our logging events for withdrawals and deposits don't change.  Our recieve function stays the same.  
+
+We need to add an additional parameter to the withdraw() function signature that allows us to specify a token name to the faucet. Then we will be able to send that token out of our faucet and to the user who requests a payout based on the name of the requested token.
+
+````
+    function withdraw(uint256 withdraw_amount, address token) public {
+
+        require(
+            address(this).balance >= withdraw_amount,
+            "Insufficient balance in faucet for withdrawal request"
+        );
+
+        require(
+            // transfer the specified token from this contract to msg.sender
+            IERC20(token).transfer(msg.sender, withdraw_amount),
+            "Withdrawing cUSD failed."
+        );
+        emit Withdrawal(msg.sender, withdraw_amount);
+    }
+````
+
+By using the ERC20 interface from Open Zeppelin, we can pass any address that points to a Celo token contract and withdraw that token from this faucet, provided there is a sufficient balance beforehand.  
+
+Here is the full Faucet.sol contract after our changes:
+
+````
+pragma solidity >=0.8.0;
+
+import "../node_modules/openzeppelin-solidity/contracts/security/ReentrancyGuard.sol";
+import "../node_modules/openzeppelin-solidity/contracts/access/Ownable.sol";
+
+import "../node_modules/openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+contract Faucet is ReentrancyGuard, Ownable {
+    event Withdrawal(address indexed to, uint256 amount);
+    event Deposit(address indexed from, uint256 amount);
+
+    address Celo = 0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9;
+    address cUSD = 0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1;
+
+    function withdraw(uint256 withdraw_amount, address token) public {
+        require(token == Celo || token == cUSD, "token is not celo or cUSD");
+
+        require(
+            address(this).balance >= withdraw_amount,
+            "Insufficient balance in faucet for withdrawal request"
+        );
+
+        require(
+            IERC20(token).transfer(msg.sender, withdraw_amount),
+            "Withdrawing cUSD failed."
+        );
+        emit Withdrawal(msg.sender, withdraw_amount);
+    }
+
+    function donate() external payable {
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    receive() external payable {
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    fallback() external payable {
+        emit Deposit(msg.sender, msg.value);
+    }
+}
+
+````
+
+This is our Ethereum faucet contract completely altered for Celo.  
+
+We even added some additional checks to make sure the token passed to the withdraw function matches the CELO or cUSD contract address.  This ensures only Celo currencies can be withdrawn from this faucet.  
+
+
+## Calling the contract
+To call this contract from a dApp kit frontend, we can run the following code.
+There is a truffle box kit that works out-of-the-box for Celo applications that we should use as our foundation for the project because it simplifies the setup process for our Celo fullstack projects.  If we're not interested in seeing our blockchain results in GUI format, we could simply quickstart a [Truffle](https://www.trufflesuite.com/docs/truffle/quickstart#compiling) project with no frontend consideration.
+
+Run the following in the root of a project directory to setup the kit:
+````bash
+truffle unbox critesjosh/celo-dappkit
+````
+
+Please note that addresses are handled as strings in Javascript and that withdraw amounts have to be handled as big numbers.  The reasons for this are outside the scope of this tutorial.  For a more in depth explanation of big numbers in Javascript please see this [article](https://ethereumdev.io/how-to-deal-with-big-numbers-in-javascript/).
+
+To deal with the big numbers we'll install the bignumber.js library. 
+
+````bash
+cd client
+npm install bignumber
+````
+
+A withdraw from faucet function would look like this.  This code could be triggered from a button press in a react application as seen in the example [here](https://github.com/BrittanyDeventer/green-deeds-celo/blob/master/client/screens/CeloScreen.js).
+
+````
+/* 
+ * To see the full context of this code snippet please view the full file:
+ * https://github.com/BrittanyDeventer/green-deeds-celo/blob/master/client/screens/CeloScreen.js
+ * ads
+ * More on async functions can be found:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
+ */
+
+  withdrawFromFaucet = async (withdrawAmount) => {
+
+    // set variables for the Celo wallet request
+    const requestId = 'withdraw_cUSD'
+    const dappName = 'Green Deeds'
+    const callback = Linking.makeUrl('/my/path')
+
+    // convert user amount to wei in bignumber format
+    let amount = parseFloat(withdrawAmount)
+    let weiAmount = BigNumber(amount*10e17)
+
+    const txObject = await this.state.faucetContract.methods.withdraw(weiAmount, cUSD)
+
+    // Send a request to the Celo wallet to send an update transaction to the Faucet contract
+    requestTxSig(
+      kit,
+      [
+        {
+          from: this.state.address,
+          to: this.state.faucetContract.options.address,
+          tx: txObject,
+          feeCurrency: FeeCurrency.cUSD
+        }
+      ],
+      { requestId, dappName, callback }
+    ).catch(err => console.log("requestTXSig Err: ", err))
+
+    // Get the response from the Celo wallet
+    const dappkitResponse = await waitForSignedTxs(requestId)
+    const tx = dappkitResponse.rawTxs[0]
+    
+    // Get the transaction result, once it has been included in the Celo blockchain
+    let result = await toTxResult(kit.web3.eth.sendSignedTransaction(tx)).waitReceipt()
+
+    console.log(`Faucet contract update transaction receipt: `, result.transactionHash)  
+    Alert.alert("Transaction Complete!",
+    `Tx Hash: ${result.transactionHash}`
+    )
+  }
+  ````
+
+
+## What we learned
+In this tutorial we learned how to alter a smart contract originally written for Ethereum and customize it for use on the Celo network. We learned about the difference between a native token such as Ether or Celo, and an ERC-20 token such as cUSD. We altered some example Solidity code to illustrate the process generally used to prepare an Ethereum contract for use on another EVM compatible network, including specific mention of alternative tokens where necessary - such as inside the withdraw function, as part of a require statement.
+
+
+As long as we understand that both blockchains are EVM compatible and run the same bytecode, we can customize any existing Ethereum contract for the Celo network.  
+
+### Next steps
+I hope this tutorial helps to see the potential in looking at existing open source code and understanding how simple modifications can lead to efficient coding solutions.  Please consider the following reading list to continue on your journey.  
+
+### Further Reading:
+-  [The Ethereum Virtual Machine](https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc)
+-  [Celo Background and Key Concepts](https://docs.celo.org/overview#background-and-key-concepts)
+-  [Open Zeppelin Source](https://github.com/pkdcryptos/OpenZeppelin-openzeppelin-solidity)
+-  [Celo Savings Circle](https://github.com/celo-org/savings-circle-demo)
+   -  Another dApp that utilizes the ERC20 interface in Celo contracts
+-  [Ethereum Book](https://github.com/ethereumbook/ethereumbook)
+
+-  [How to deal with big numbers in Javascript](https://ethereumdev.io/how-to-deal-with-big-numbers-in-javascript/)
+-  [Celo for Ethereum Developers](https://docs.celo.org/developer-guide/celo-for-eth-devs)
+-  [Truffle Quickstart](https://www.trufflesuite.com/docs/truffle/quickstart#compiling)

--- a/network-documentation/celo/tutorial/how-to-customize-an-ethereum-smart-contract-for-the-celo-network.md
+++ b/network-documentation/celo/tutorial/how-to-customize-an-ethereum-smart-contract-for-the-celo-network.md
@@ -1,2 +1,0 @@
-# How to customize an Ethereum smart contract for the Celo network
-

--- a/network-documentation/celo/tutorial/how-to-successfully-connect-to-a-celo-wallet-with-a-react-native-dapp.md
+++ b/network-documentation/celo/tutorial/how-to-successfully-connect-to-a-celo-wallet-with-a-react-native-dapp.md
@@ -1,2 +1,361 @@
-# How to successfully connect to a Celo Wallet with a React Native DApp
+---
+description: How to successfully connect to a Celo Wallet with a React Native DApp
+---
+
+# How to successfully set up a Celo Wallet with a React Native DApp using Redux
+## About the Authors
+
+This tutorial was created by [Segun Ogundipe](https://www.linkedin.com/in/segun-ogundipe) and [Emmanuel Oaikhenan](https://github.com/emmaodia).
+## Introduction
+
+**In this tutorial you will learn how to successfully connect your React Native App to use the Celo Wallet and return a Wallet Address from the Alfajores Wallet.**
+
+_To carry out transactions on the Celo Network, you have to connect your Wallet to be able to carry out transactions. When you start out building a dAPP using React Native, you will need this guide to demonstrate how you can install the required libraries to get your dApp up and running._
+
+&nbsp;
+
+# Prerequisite
+
+This article assumes that you have basic knowledge of JavaScript (TypeScript) and how to start a React Native App using expo. It is also assumed that you have read the expo documentation and have basic knowledge of the Celo Wallet.
+
+1. [Celo Wallet](https://docs.celo.org/getting-started/alfajores-testnet/using-the-mobile-wallet)
+2. [React Native using expo](https://docs.expo.io/)
+3. [DappKit](https://docs.celo.org/developer-guide/dappkit/setup)
+
+&nbsp;
+
+# Project Setup
+
+You will need node version `^10.13.0`.
+
+Open the Celo documentation and follow the set up instructions:
+
+`expo init $YOUR_APP_NAME`
+
+We will use the `TypeScript Template >> Tabs`
+<img src="./images/terminalImage.png" width="600" height="150" />
+
+To use the Celo DappKit, install using:
+
+`yarn add @celo/dappkit`
+
+DAppKit's dependencies require a bit of adjustment to use vanilla Expo. The first are a lot of the Node.js modules that are expected. You can get those mostly by using the following modules:
+
+`yarn add node-libs-react-native vm-browserify`
+
+**Important Note!**
+
+The default React Native library that is installed with the expo package will cause your app to break. To fix this, go to the `package.json` file and replace the `react-native` version value:
+
+with this: `^0.63.4` at the time of writing this tutorial. You can always use the most recent version of React Native.
+
+**A Note on the installed Packages**
+
+_node-libs-react-native_:
+This package provides React Native compatible implementations of Node core modules like stream and http. This is a fork of node-libs-browser with a few packages swapped to be compatible in React Native.
+
+_vm-browserify_ is used to emulate node's vm module for the browser.
+
+**A couple of points to note:**
+
+_The metro.config.js file_
+
+```javascript
+const crypto = require.resolve('crypto-browserify');
+const url = require.resolve('url/');
+module.exports = {
+  resolver: {
+    extraNodeModules: {
+      crypto,
+      url,
+      fs: require.resolve('expo-file-system'),
+      http: require.resolve('stream-http'),
+      https: require.resolve('https-browserify'),
+      net: require.resolve('react-native-tcp'),
+      os: require.resolve('os-browserify/browser.js'),
+      path: require.resolve('path-browserify'),
+      stream: require.resolve('readable-stream'),
+      vm: require.resolve('vm-browserify'),
+    },
+  },
+};
+```
+
+This should allow you to build the project, however some dependencies might expect certain invariants on the global environment. For that you should create a file `global.ts` with the content below:
+
+```javascript
+export interface Global {
+  btoa: any
+  self: any
+  Buffer: any
+  process: any
+  location: any
+}
+
+declare var global: Global
+if (typeof global.self === 'undefined') {
+  global.self = global
+}
+
+if (typeof btoa === 'undefined') {
+  global.btoa = function (str: string) {
+    return new Buffer(str, 'binary').toString('base64')
+  }
+}
+
+global.Buffer = require('buffer').Buffer
+global.process = require('process')
+global.location = {
+  protocol: 'https',
+}
+```
+
+And then add `import './global'` at the top of your `App.js/tsx` file
+
+**Set up Redux**
+
+Install the Redux libraries using the following command:
+
+`yarn add redux redux-thunk redux-logger react-redux`
+
+For TypeScript to run redux logger locally without any errors, you have to add the library `@types/redux-logger` to the devDependencies using the command:
+
+`yarn add @types/redux-logger --dev`
+
+Run the app using: `expo start`
+
+Find documentation how to run your app [here]()
+
+&nbsp;
+
+# Code
+
+After installing the required libraries, we can then build 2 simple screens in the React Native app.
+
+The first screen will have one button. The button will be used to sign a User into the dApp.
+
+The second screen will be the screen that proves that the user has successfully authenticated. The second screen will return the user's wallet address.
+
+**Let's build the Screens:**
+
+```javascript
+export default function LoginScreen() {
+  return (
+    <View style={styles.container}>
+      <Button>Connect Wallet</Button>
+    </View>
+  );
+}
+```
+
+<img src="./images/LoginScreen.png" width="300" height="600" />
+
+Login Screen
+
+```javascript
+export default function HomeScreen() {
+  return (
+    <View>
+      <Text>wallet address</Text>
+      <Text>wallet phone</Text>
+    </View>
+  );
+}
+```
+
+**Let's implement the Logic to connect to the Wallet:**
+
+We will use Redux to manage the app state, we have to set up redux actions to make a call to the Celo Wallet and return the result which is then saved in the app global state. To keep your directory devoid of clutter, open a directory to hold the files for the Redux logic:
+
+<img src="./images/ReduxDirectory.png" width="300" height="150" />
+
+You can add a file called `constants.js` to the Redux Store Directory. The constants will be used to track the wallet connection process by having the constants as the type of action that was dispatched and then update the state accordingly using a reducer.
+
+```javascript
+export const walletConstants = {
+  CONNECT_REQUEST: 'WALLET_CONNECT_REQUEST',
+  CONNECT_SUCCESS: 'WALLET_CONNECT_SUCCESS',
+  CONNECT_FAILURE: 'WALLET_CONNECT_FAILURE',
+};
+```
+
+Create a `walletsAction.ts` file in the actions folder
+
+```javascript
+/*
+ The export statement is used to export the only function in the file so that the function can be called using `walletsActions.connect()`
+ */
+export const walletActions = {
+  connect,
+};
+
+/*
+This function is a simple method provided by Celo to connect to the Valora or Alfajores (for testing) wallet. The `dispatch()` is a redux function which is used to emit actions which we can then listen for in the reducer and update the state accordingly.
+*/
+function connect() {
+  return (dispatch: any) => {
+    // This dispatch calls a function that is declared later on in the code.
+    dispatch(request('Connecting to wallet'));
+
+    // These variables are needed to connect to the wallet
+    // requestId is used to identify the request so we can listen for the same request using the waitForAccoutAuth() function
+    // dappName holds the name of the App the wallet will expose as requesting for the detaila
+    // callback is the screen we want to send the user to after a successfull connection is made
+    const requestId = 'dapplogin';
+    const dappName = 'celodapp';
+    const callback = Linking.makeUrl('two');
+
+    //T his is from the Celo DappKit library, it fires up the wallet and gets the neccessary information
+    requestAccountAddress({
+      requestId,
+      dappName,
+      callback,
+    });
+
+    //This function listens for the request above and fire up an action to be handled by a reducer.
+    waitForAccountAuth(requestId)
+      .then((res) => {
+        dispatch(success(res));
+      })
+      .catch((err) => {
+        dispatch(failure(err));
+        dispatch(alertActions.error(err.toString()));
+      });
+  };
+
+  //These are the function calls which are dispatched when the user makes a request. The state of the app changes with the status of the request response.
+  function request(message: string) {
+    return { type: walletConstants.CONNECT_REQUEST, message };
+  }
+  function success(res: object) {
+    return { type: walletConstants.CONNECT_SUCCESS, res };
+  }
+  function failure(error: any) {
+    return { type: walletConstants.CONNECT_FAILURE, error };
+  }
+}
+```
+
+The above file is the `walletAction.ts` It contains the logic to connect to the Wallet and saves the response in the global redux state which is accessible to any part of the codebase. The next thing will be to write the reducer logic to handle the app state modification.
+
+Create a `walletReducer.ts` file in the reducers folder
+
+```javascript
+//T he initial state of the wallet
+const initialState = {
+  failed: true,
+  connecting: false,
+  message: '',
+  address: '',
+  phone: '',
+};
+
+// This is the wallet reducer which takes the state and action as parameters.
+// It modifies the state accordingly based on the type of action that it receives from the dispatch calls in the `walletAction.ts` file
+export function wallet(state = initialState, action: any) {
+  switch (action.type) {
+    case walletConstants.CONNECT_REQUEST:
+      return {
+        connecting: true,
+        message: action.message,
+      };
+    case walletConstants.CONNECT_SUCCESS:
+      return {
+        failed: false,
+        address: action.res.address,
+        phone: action.res.phoneNumber,
+      };
+    case walletConstants.CONNECT_FAILURE:
+      return {
+        error: action.error,
+      };
+    default:
+      return state;
+  }
+}
+```
+
+Create a `store.ts` file in the store folder
+
+```javascript
+// This is where the store is setup. This is where redux updates the state of the store based on the user actions.
+import { createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import { createLogger } from 'redux-logger';
+
+import { rootReducer } from './reducers';
+
+const loggerMiddleware = createLogger();
+
+export const store = createStore(rootReducer, applyMiddleware(thunkMiddleware, loggerMiddleware));
+```
+
+Let's update the `App.tsx` file with the Redux Provider.
+
+```Javascript
+//The Redux Provider wraps around the entire application
+export default function App() {
+  return (
+    <Provider store={store}>
+    ...
+    </Provider>
+  );
+}
+```
+
+Time to update the LoginScreen and the HomeScreen with the Redux Actions:
+
+```javascript
+//The useDispatch is a React Redux Hook to dispatch an action creator.
+export default function HomeScreen() {
+  const dispatch = useDispatch();
+
+  // This function calls up the connect function from the walletAction Action
+  const login = () => {
+    dispatch(walletActions.connect());
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button onPress={login}>Connect Wallet</Button>
+    </View>
+  );
+}
+```
+
+Also update the HomeScreen and the HomeScreen with the Redux Actions:
+
+```javascript
+// Here, we connect to the global state with useSelector hook
+export default function HomeScreen() {
+  const wallet = useSelector((state: any) => state.wallet);
+
+  // We make sure to handle instances where a user tries to navigate to this page without connecting the app to their wallet by making sure to navigate back to the loginscreen if a connection to the wallet hasn't been made yet
+  React.useEffect(() => {
+    if (wallet.failed) {
+      navigation.navigate('Root');
+    }
+  }, []);
+
+  return (
+    <View>
+      <Text>{wallet.address}</Text>
+      <Text>{wallet.phone}</Text>
+    </View>
+  );
+}
+```
+
+Run your app and Login to see the Wallet and Phone number returned to the Home Screen.
+
+<img src="./images/WalletScreen.png" width="300" height="600" /> <img src="./images/HomeScreen.png" width="300" height="600" />
+
+&nbsp;
+
+# Conclusion
+
+This was a very interesting tutorial. In this tutorial, we learned:
+**How to successfully connect your Redux based React Native App to use the Celo Wallet and return a Wallet Address from the Valora/Alfajores Wallet.**
+
+&nbsp;
 


### PR DESCRIPTION
@guillaumegaluz I just fixed both the broken links/tutorials which are as follows - 

- Celo Contract from Ethereum
- How to successfully connect to a cell wallet with a React Native DApp.