### PR TITLE
Update README.md with new avalanche tutorial

### DIFF
--- a/network-documentation/avalanche/tutorials/README.md
+++ b/network-documentation/avalanche/tutorials/README.md
@@ -48,6 +48,10 @@ Don't forget that you can try them out [**via Datahub**](https://datahub.figment
 
 {% page-ref page="transfer-avax-between-the-x-chain-and-c-chain.md" %}
 
+## Making an e-Voting dApp on Avalanche Fuji network using Trufflesuite
+
+{% page-ref page="making-evoting-dapp-on-avalanche-c-chain-using-truffle.md" %}
+
 ## Creating a Fixed-Cap Asset
 
 {% page-ref page="creating-a-fixed-cap-asset.md" %}


### PR DESCRIPTION
I forgot to update the README.md file in the network-documentation for referencing my new tutorial. Please consider this commit as a fix. Thank you.