### PR TITLE
Updating jsdelivr link with a working one

### DIFF
--- a/network-documentation/avalanche/tutorials/making-evoting-dapp-on-avalanche-c-chain-using-truffle.md
+++ b/network-documentation/avalanche/tutorials/making-evoting-dapp-on-avalanche-c-chain-using-truffle.md
@@ -372,7 +372,7 @@ app.listen(process.env.PORT || 3000, () => {
   <script language="javascript" type="text/javascript" src="https://cdn.jsdelivr.net/gh/ethereum/web3.js@1.0.0-beta.34/dist/web3.js"></script>
 
   <!--Truffle Contract module for interacting with smart contract in javascript-->
-  <script src="https://cdn.jsdelivr.net/gh/rajranjan0608/ethereum-electionVoting/src/contract.js"></script>
+  <script src="https://rajranjan0608.github.io/ethereum-electionVoting/src/contract.js"></script>
 
   <!--Our custom javascript code for interaction-->
   <script type="module" language="javascript" src="index.js"></script>


### PR DESCRIPTION
The `./src/index.html` file was unable to fetch the `contract.js` file from `jsdelivr.net` 
Therefore I am updating the HTML file with a new working link. Thank you.