### PR TITLE
Adds missing 'not' in ft_on_transfer_call description

### DIFF
--- a/network-documentation/near/tutorials/1-project_overview/2-fungible-token.md
+++ b/network-documentation/near/tutorials/1-project_overview/2-fungible-token.md
@@ -228,7 +228,7 @@ The method must return the number of tokens that are not used/accepted by this c
 
 * `msg` - a string message that was passed with this transfer call.
 
-Returns the number of tokens that are used/accepted by this contract from the transferred amount.
+Returns the number of tokens that are not used/accepted by this contract from the transferred amount.
 
 **What purpose does msg serve?**
 


### PR DESCRIPTION
# Description*

Adds missing 'not' in ft_on_transfer_call description

Fixes # (issue)

N/A

## Type of change*

- [X] Typo fix

## This PR created for* - 

Important - Please delete option that's not relevant to your PR.

- [X] Figment Learn Docs (Pathway, Existing Tutorials, New Tutorial etc.) changes/updates/fixes

# How Has This Been Tested? (If Applicable)

N/A

# Checklist*:

- [X] I checked and read the contribution guide before making this PR [**HERE**](https://learn.figment.io/figment-learn/contribute)  
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

# Other Information (Optional)
*Please add any other information/details you would like to let us know related to your proposed changes and PR*

Note - Above ponits marked with * are mandatory to fill :)
