### PR TITLE
Updated typo in base units

### DIFF
--- a/network-documentation/celo/tutorial/intro-pathway-celo-basics/4.transactions.md
+++ b/network-documentation/celo/tutorial/intro-pathway-celo-basics/4.transactions.md
@@ -79,7 +79,7 @@ main().catch((err) => {
 
 Ok, let’s break it down. After we initialize the account with our private key, we need to add the account to ContractKit in order to be able to sign transactions. Then, we specify the recipient’s address and the amount we want to transfer. In this case, we will be transferring `100000 base CELO units` to the address `0xD86518b29BB52a5DAC5991eACf09481CE4B0710d`.
 
-Here you can notice that we mentioned base Celo units. Since Javascript does not have floating-point numbers, it is common to convert integers to large numbers \(BigNumber\) before doing arithmetic. In the case of Celo, 1 CELO = 1018 base units of CELO.
+Here you can notice that we mentioned base Celo units. Since Javascript does not have floating-point numbers, it is common to convert integers to large numbers \(BigNumber\) before doing arithmetic. In the case of Celo, 1 CELO = 1e18 base units of CELO (same for stable tokens like cUSD and cEUR).
 
 What is interesting about the code above is that we don’t call the transfer method directly on the ContractKit client. Instead, we first, get contract wrappers. Celo has a number of core Smart Contracts that are deployed to the network. In this example. we use GoldToken and StableToken contract wrappers, which both have the `transfer` function allowing us to build a transfer transaction. Here we build a transfer transaction to the same account for the same amount of CELO and cUSD. Don’t forget to call the `send` method, which takes a transfer transaction and broadcasts it to the Celo Alfajores network.
 


### PR DESCRIPTION
A typo in the docs. It should be 1 CELO = 1e18 base units of CELO.

# Description*

A typo in the docs. It should be 1 CELO = 1e18 base units of CELO.

Fixes # (issue)

Causes confusion among builders

## Type of change*

Important - Please delete options that are not relevant to your PR.

N/A

## This PR created for* - 

Important - Please delete option that's not relevant to your PR.

N/A

# How Has This Been Tested? (If Applicable)

N/A

# Checklist*:

N/A

# Other Information (Optional)
N/A

Note - Above points marked with * are mandatory to fill :)
