### PR TITLE
Updated hyperlink to open the Celo Dapp Gallery

### DIFF
--- a/network-documentation/celo/celo-101.md
+++ b/network-documentation/celo/celo-101.md
@@ -36,7 +36,7 @@ Celo enables developers to build a new financial system to empower their users. 
 * Use the full suite of Ethereum smart contracts right off the shelf
 
   
- You can view some of the projects that are building on Celo [here](https://docs.celo.org/developer-guide/overview/celo-dapp-gallery). 
+ You can view some of the projects that are building on Celo [here](https://docs.celo.org/developer-guide/celo-dapp-gallery). 
 
 ## **Network Specifications**
 


### PR DESCRIPTION
#129    
The problem was highlighted in issue #129 
Problem : The existing hyperlink URL was not directing to the correct page: [Incorrect URL](https://docs.celo.org/developer-guide/overview/celo-dapp-gallery)
![image](https://user-images.githubusercontent.com/43913734/122218990-a0b81180-cecc-11eb-8a9f-fe8bc4b14bb8.png)



Solution: I have updated the correct URL of the Celo Dapp Gallery: [Correct URL](https://docs.celo.org/developer-guide/celo-dapp-gallery)
![image](https://user-images.githubusercontent.com/43913734/122218961-972ea980-cecc-11eb-8b79-ae5ad1bf4012.png)



Cheers!

Thanks for submitting this tutorial for Figment Learn!

Before you hit "Create Pull Request" make sure you have read the [Tutorial Contribution Guidelines](https://app.gitbook.com/@figment-learn/s/learn-docs/other/tutorial-guidelines). If you don't follow those guidelines it might take longer for us to review.

- [x] My tutorial follows the [Tutorial Contribution Guidelines](https://app.gitbook.com/@figment-learn/s/learn-docs/other/tutorial-guidelines).

In particular:

- [x] I've followed the [template structure](Structure).
- [x] I've proofread the tutorial for spelling and grammar mistakes.
- [x] I've ran a linter & prettifier to format my code blocks.
- [x] I've thoroughlly explained the code, with inline code comments and text explanations.
- [x] I've ran the tutorial and the code works.
