### PR TITLE
make the contract label unique using the address

### DIFF
--- a/figment-learn/new-pathways/secret/secret-05-deploy.md
+++ b/figment-learn/new-pathways/secret/secret-05-deploy.md
@@ -1,8 +1,9 @@
 We won't go through the process of reviewing the smart contract code base, compiling it or testing it. We will focus instead on how one can deploy a smart contract using the `secretjs` library. To do this, we're going to use a pre-compiled smart contract, you can find it under `./contract/secret/contract.wasm`.
 
 Our contract implements a simple counter. The contract is created with a parameter for the initial count and allows subsequent incrementing:
-* The `get_count` function returns the value of the counter stored on the contract.
-* The `increment` function increases the value of the counter stored on the contract by 1.
+
+- The `get_count` function returns the value of the counter stored on the contract.
+- The `increment` function increases the value of the counter stored on the contract by 1.
 
 {% hint style="working" %}
 If you want to learn more about Secret smart contracts, follow the [**Developing your first secret contract**](https://learn.figment.io/tutorials/creating-a-secret-contract-from-scratch) tutorial.
@@ -15,24 +16,24 @@ You could experience some issues with the availability of the network [**Click h
 Before, focusing on the deployment instructions, let's take a look at some important global variables:
 
 ```typescript
-const CONTRACT_PATH = './contracts/secret/contract.wasm' 
+const CONTRACT_PATH = "./contracts/secret/contract.wasm";
 
 const customFees = {
   upload: {
-    amount: [{ amount: '2000000', denom: 'uscrt' }],
-    gas: '2000000',
+    amount: [{ amount: "2000000", denom: "uscrt" }],
+    gas: "2000000",
   },
   init: {
-    amount: [{ amount: '500000', denom: 'uscrt' }],
-    gas: '500000',
-  }
+    amount: [{ amount: "500000", denom: "uscrt" }],
+    gas: "500000",
+  },
 };
 ```
 
-* `CONTRACT_PATH` is pointing to the location of the optimized **WebAssembly** version of the smart contract.  
-* The `customFees` object stores the predefined amount of fees to pay in order to **upload** and **initialize** the smart contract. [Click here](https://github.com/enigmampc/SecretNetwork/blob/7adccb9a09579a564fc90173cc9509d88c46d114/cosmwasm-js/packages/sdk/src/signingcosmwasmclient.ts#L48) to check out the default fee table in the `SigningCosmWasmClient` source. 
+- `CONTRACT_PATH` is pointing to the location of the optimized **WebAssembly** version of the smart contract.
+- The `customFees` object stores the predefined amount of fees to pay in order to **upload** and **initialize** the smart contract. [Click here](https://github.com/enigmampc/SecretNetwork/blob/7adccb9a09579a564fc90173cc9509d88c46d114/cosmwasm-js/packages/sdk/src/signingcosmwasmclient.ts#L48) to check out the default fee table in the `SigningCosmWasmClient` source.
 
-----------------------------------
+---
 
 # Challenge
 
@@ -44,24 +45,25 @@ In `pages/api/secret/deploy.ts`, implement the default function. Upload your fir
 
 ```tsx
 //...
-  // Upload the contract wasm
-  const wasm = fs.readFileSync(CONTRACT_PATH);
-  const uploadReceipt = await client.undefined;
-  if (!uploadReceipt) {
-    throw new Error("uploadReceipt error");
-  }
-  // Get the code ID from the receipt
-  const { codeId } = uploadReceipt;
+// Upload the contract wasm
+const wasm = fs.readFileSync(CONTRACT_PATH);
+const uploadReceipt = await client.undefined;
+if (!uploadReceipt) {
+  throw new Error("uploadReceipt error");
+}
+// Get the code ID from the receipt
+const { codeId } = uploadReceipt;
 
-  // Create an instance of the Counter contract, providing a starting count
-  const initMsg = { count: 101 };
-  const receipt = undefined;
+// Create an instance of the Counter contract, providing a starting count
+const initMsg = { count: 101 };
+const receipt = undefined;
 //...
 ```
 
 **Need some help?**
-* [**Contract example**](https://github.com/enigmampc/SecretJS-Templates/tree/master/5_contracts)  
-* [**The `upload` function**](https://github.com/enigmampc/SecretNetwork/blob/7adccb9a09579a564fc90173cc9509d88c46d114/cosmwasm-js/packages/sdk/src/signingcosmwasmclient.ts#L208)  
+
+- [**Contract example**](https://github.com/enigmampc/SecretJS-Templates/tree/master/5_contracts)
+- [**The `upload` function**](https://github.com/enigmampc/SecretNetwork/blob/7adccb9a09579a564fc90173cc9509d88c46d114/cosmwasm-js/packages/sdk/src/signingcosmwasmclient.ts#L208)
 
 {% hint style="info" %}
 You can [**join us on Discord**](https://discord.gg/fszyM7K), if you have questions or want help completing the tutorial.
@@ -69,39 +71,39 @@ You can [**join us on Discord**](https://discord.gg/fszyM7K), if you have questi
 
 Still not sure how to do this? No problem! The solution is below so you don't get stuck.
 
-----------------------------------
+---
 
 # Solution
 
 ```tsx
 // solution
 //...
-  // Upload the contract wasm
-  const wasm = fs.readFileSync(CONTRACT_PATH);
-  const uploadReceipt = await client.upload(wasm, {});
-  if (!uploadReceipt) {
-    throw new Error("uploadReceipt error");
-  }
-  // Get the code ID from the receipt
-  const { codeId } = uploadReceipt;
+// Upload the contract wasm
+const wasm = fs.readFileSync(CONTRACT_PATH);
+const uploadReceipt = await client.upload(wasm, {});
+if (!uploadReceipt) {
+  throw new Error("uploadReceipt error");
+}
+// Get the code ID from the receipt
+const { codeId } = uploadReceipt;
 
-  // Create an instance of the Counter contract, providing a starting count
-  const initMsg = { count: 101 };
-  const receipt = await client.instantiate(codeId, initMsg, `My Counter${Math.ceil(Math.random() * 10000)}`);
+// Create an instance of the Counter contract, providing a starting count
+const initMsg = { count: 101 };
+const receipt = await client.instantiate(codeId, initMsg, address.slice(6));
 //...
 ```
 
 **What happened in the code above?**
 
-* First, we upload the contract using `upload` method of the `SigningCosmWasmClient`.
-* Next, we destructure the `uploadReceipt` response object to get the `codeId` of the deployed contract
-* Finally, we instantiate the contract using `instantiate` method of the `SigningCosmWasmClient`, passing:
-  * The `codeId`.
-  * The `initMsg` contract method to instantiate the storage with a value of `101`.
-  * A label, which needs to be unique.
-  * Optionally, we could also include a memo, a transfer amount, fees, and a code hash. For this example, these arguments are unnecessary.
+- First, we upload the contract using `upload` method of the `SigningCosmWasmClient`.
+- Next, we destructure the `uploadReceipt` response object to get the `codeId` of the deployed contract
+- Finally, we instantiate the contract using `instantiate` method of the `SigningCosmWasmClient`, passing:
+  - The `codeId`.
+  - The `initMsg` contract method to instantiate the storage with a value of `101`.
+  - A label, which needs to be unique, which is why we use a slice of the address.
+  - Optionally, we could also include a memo, a transfer amount, fees, and a code hash. For this example, these arguments are unnecessary.
 
-----------------------------------
+---
 
 # Make sure it works
 
@@ -109,7 +111,7 @@ Once you have the code above saved, click on **Deploy Contract**
 
 ![](../../../.gitbook/assets/pathways/secret/secret-deploy.gif)
 
-----------------------------------
+---
 
 # Conclusion
 


### PR DESCRIPTION
To override the possible collision regarding the contract label we need to make the latter unique. Then it has been decided to use a slice of the address of the owner of the contract. As unicity is a building feature of an address we have an easy way to solve the collision issue of contract label.

![Screenshot_20211020_045430](https://user-images.githubusercontent.com/529836/138021934-e7fc7530-679a-4207-9c80-07595b806a45.png)


